### PR TITLE
Change item name input from datalist to plain field

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -17,12 +17,7 @@
 </header>
 <main>
     <form id="item-form" autocomplete="off">
-        <input type="text" id="item-name" placeholder="Artikel" list="items-list" required maxlength="50">
-        <datalist id="items-list">
-            <option value="Apfel"></option>
-            <option value="Brot"></option>
-            <option value="Milch"></option>
-        </datalist>
+        <input type="text" id="item-name" placeholder="Artikel" required maxlength="50">
         <input type="number" id="item-piece" placeholder="Stück" min="1" value="1">
         <input type="number" id="item-amount" placeholder="Menge" step="0.01" min="0" value="0">
         <select id="item-unit">


### PR DESCRIPTION
## Summary
- remove `datalist` element and `list` attribute from item name input

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596f40cb4083228d0aa78d3adc86e4